### PR TITLE
Get statistics command

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,33 @@
+# see: https://goreleaser.com
+before:
+  hooks:
+    - go mod tidy
+builds:
+  - env:
+      - CGO_ENABLED=0
+    # https://goreleaser.com/customization/build/
+    id: ggs
+    binary: ggs
+    goos:
+      - linux
+      - windows
+      - darwin
+    ldflags:
+      - -X main.revision={{.ShortCommit}}
+archives:
+  - replacements:
+      darwin: Darwin
+      linux: Linux
+      windows: Windows
+      386: i386
+      amd64: x86_64
+checksum:
+  name_template: "checksums.txt"
+snapshot:
+  name_template: "{{ incpatch .Version }}-next"
+changelog:
+  sort: asc
+  filters:
+    exclude:
+      - "^docs:"
+      - "^test:"

--- a/README.md
+++ b/README.md
@@ -7,11 +7,10 @@ CLI tool for git statistics
 ### _repo_
 
 Get all repositories.
-Sample files are found [here](./cmd/generate/_examples).
 
 ```sh
 # When Github access token is set to GGS_TOKEN (environment variable)
-$ echo $GSS_TOKEN
+$ echo $GGS_TOKEN
 > ghq_....
 
 # Repositories for authenticated user with Github access token
@@ -22,6 +21,21 @@ $ ggs r
 # Public repositories without Github access token
 $ ggs repo -name kokoichi206
 $ ggs r -n kokoichi206
+```
+
+### _stats_
+
+Get statistics of a specific repository.
+
+```sh
+# Github access token should be set to GGS_TOKEN (environment variable)
+# when you get private repopsitory stats.
+$ echo $GGS_TOKEN
+> ghq_....
+
+$ ggs stats -name kokoichi206/go-git-stats
+# abbreviation command
+$ ggs s -name kokoichi206/go-git-stats
 ```
 
 ## INSTALLATION

--- a/api/apicaller.go
+++ b/api/apicaller.go
@@ -6,4 +6,5 @@ package api
 type ApiCaller interface {
 	ListPublicRepositories(userName string) ([]Repository, error)
 	ListRepositoriesForAuthenticatedUser() ([]Repository, error)
+	WeeklyCommitActivity(fullName string) ([]CodeFrequency, error)
 }

--- a/api/mock/api.go
+++ b/api/mock/api.go
@@ -8,15 +8,19 @@ import (
 type MockApi struct {
 	config              util.Config
 	ListRepos           []api.Repository
+	ListCodeFreq        []api.CodeFrequency
 	Error               error
 	PublicCalled        bool
 	AuthenticatedCalled bool
+	WeeklyCodeCalled    bool
+	PassedFullName      string
 }
 
 func (a *MockApi) InitMock() {
 	a.Error = nil
 	a.PublicCalled = false
 	a.AuthenticatedCalled = false
+	a.WeeklyCodeCalled = false
 }
 
 func (a *MockApi) ListPublicRepositories(userName string) ([]api.Repository, error) {
@@ -27,6 +31,12 @@ func (a *MockApi) ListPublicRepositories(userName string) ([]api.Repository, err
 func (a *MockApi) ListRepositoriesForAuthenticatedUser() ([]api.Repository, error) {
 	a.AuthenticatedCalled = true
 	return a.ListRepos, a.Error
+}
+
+func (a *MockApi) WeeklyCommitActivity(fullName string) ([]api.CodeFrequency, error) {
+	a.WeeklyCodeCalled = true
+	a.PassedFullName = fullName
+	return a.ListCodeFreq, a.Error
 }
 
 func New(config util.Config) *MockApi {

--- a/api/models.go
+++ b/api/models.go
@@ -6,3 +6,9 @@ type Repository struct {
 	Name     string `json:"name"`
 	FullName string `json:"full_name"`
 }
+
+type CodeFrequency struct {
+	Time      int
+	Additions int
+	Deletions int
+}

--- a/api/repository.go
+++ b/api/repository.go
@@ -77,7 +77,6 @@ func (a *Api) ListRepositoriesForAuthenticatedUser() ([]Repository, error) {
 
 	// Set request header.
 	req.Header.Add("Accept", "application/vnd.github+json")
-	a.config.Token = "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"
 	req.Header.Add("Authorization", fmt.Sprintf("token %s", a.config.Token))
 
 	var resp *http.Response

--- a/api/stats.go
+++ b/api/stats.go
@@ -1,0 +1,82 @@
+package api
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+)
+
+// Get the weekly commit activity of a specific repository.
+// See documentation:
+// https://docs.github.com/ja/rest/metrics/statistics#get-the-weekly-commit-activity
+func (a *Api) WeeklyCommitActivity(fullName string) ([]CodeFrequency, error) {
+
+	var (
+		URL         = fmt.Sprintf("https://api.github.com/repos/%s/stats/code_frequency", fullName)
+		retries     = 3
+		waitSeconds = 3 * time.Second
+	)
+
+	client := &http.Client{}
+	req, err := http.NewRequest("GET", URL, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	// Set request header.
+	req.Header.Add("Accept", "application/vnd.github+json")
+	if a.config.Token != "" {
+		req.Header.Add("Authorization", fmt.Sprintf("token %s", a.config.Token))
+	}
+
+	var resp *http.Response
+	for retries > 0 {
+		resp, err = client.Do(req)
+
+		// If the StatusCode starts with 4, it is user's error,
+		// so it should not be retried.
+		if resp.StatusCode/100 == 4 {
+			return nil, err
+		}
+
+		if resp.StatusCode == 202 {
+			// Failed to find cache and GitHub started to create statistics.
+			// Sleep some time and retry.
+			time.Sleep(waitSeconds)
+		} else if err != nil {
+			retries -= 1
+		} else {
+			// Success!
+			break
+		}
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	defer resp.Body.Close()
+	if err != nil {
+		return nil, err
+	}
+
+	var cf [][]int
+	if err := json.Unmarshal(body, &cf); err != nil {
+		return nil, err
+	}
+
+	// MAYBE: there's better way.
+	// Convert array to CodeFrequency
+	var codeFreqs []CodeFrequency
+	for i := len(cf) - 1; i >= 0; i-- {
+		c := cf[i]
+		if len(c) == 3 {
+			codeFreqs = append(codeFreqs, CodeFrequency{
+				Time:      c[0],
+				Additions: c[1],
+				Deletions: c[2],
+			})
+		}
+	}
+
+	return codeFreqs, nil
+}

--- a/cmd/commands.go
+++ b/cmd/commands.go
@@ -16,5 +16,6 @@ type Cmd struct {
 func (c *Cmd) NewCommands() []*cli.Command {
 	return []*cli.Command{
 		c.RepoCommand(),
+		c.StatsCommand(),
 	}
 }

--- a/cmd/stats.go
+++ b/cmd/stats.go
@@ -1,0 +1,46 @@
+package cmd
+
+import (
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/urfave/cli/v2"
+)
+
+// Return cli command about repositories.
+func (c *Cmd) StatsCommand() *cli.Command {
+	return &cli.Command{
+		Name:        "stats",
+		Aliases:     []string{"s"},
+		Description: "Get stats of a specific repository",
+		Flags: []cli.Flag{
+			&cli.StringFlag{Name: "name", Aliases: []string{"n"}},
+		},
+		Action: c.getStatistics,
+	}
+}
+
+// Get statistics of a specific repository.
+// If the github access token is set to Config,
+// you can get stats of a private repository.
+func (c *Cmd) getStatistics(cc *cli.Context) error {
+	// get fullName (<userName>/<repo>)
+	fullName := cc.String("name")
+	if fullName == "" {
+		// not correct usage
+		return errors.New("name flag is not given.")
+	}
+
+	rs, err := c.Api.WeeklyCommitActivity(fullName)
+	if err != nil {
+		fmt.Println(err)
+		return err
+	}
+
+	fmt.Printf("%-30s\t%-10s\t%-5s\n", "Start Time", "Additions", "Deletions")
+	for _, r := range rs {
+		fmt.Printf("%s\t%10d\t%5d\n", time.Unix(int64(r.Time), 0), r.Additions, r.Deletions)
+	}
+	return nil
+}

--- a/cmd/stats_test.go
+++ b/cmd/stats_test.go
@@ -1,0 +1,98 @@
+package cmd
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/kokoichi206/go-git-stats/api"
+	"github.com/kokoichi206/go-git-stats/api/mock"
+	"github.com/kokoichi206/go-git-stats/util"
+	"github.com/stretchr/testify/require"
+	"github.com/urfave/cli/v2"
+)
+
+func TestStatsCommand(t *testing.T) {
+
+	config := util.LoadConfig()
+	mockApi := mock.New(config)
+
+	c := Cmd{
+		Config: config,
+		Api:    mockApi,
+	}
+
+	app := cli.NewApp()
+	app.Commands = c.NewCommands()
+
+	testCases := []struct {
+		name      string
+		commands  []string
+		setup     func()
+		assertion func(t *testing.T, err error, api *mock.MockApi)
+		tearDown  func()
+	}{
+		{
+			name:     "OK",
+			commands: []string{"", "stats", "-name", "kokoichi206/go-git-stats"},
+			setup: func() {
+				mockApi.ListCodeFreq = []api.CodeFrequency{
+					{
+						Time:      1659830400,
+						Additions: 10_0000,
+						Deletions: 999,
+					},
+				}
+			},
+			assertion: func(t *testing.T, err error, api *mock.MockApi) {
+				require.NoError(t, err)
+				require.True(t, api.WeeklyCodeCalled)
+				require.Equal(t, "kokoichi206/go-git-stats", api.PassedFullName)
+			},
+			tearDown: func() {
+				mockApi.InitMock()
+			},
+		},
+		{
+			name:     "No fullName",
+			commands: []string{"", "stats"},
+			setup:    func() {},
+			assertion: func(t *testing.T, err error, api *mock.MockApi) {
+				require.Error(t, err)
+				require.False(t, api.WeeklyCodeCalled)
+			},
+			tearDown: func() {
+				mockApi.InitMock()
+			},
+		},
+		{
+			name:     "API call error",
+			commands: []string{"", "stats", "-name", "kokoichi206/go-git-stats"},
+			setup: func() {
+				mockApi.Error = errors.New("mock Error: No fullName test")
+			},
+			assertion: func(t *testing.T, err error, api *mock.MockApi) {
+				require.Error(t, err)
+				require.True(t, api.WeeklyCodeCalled)
+			},
+			tearDown: func() {
+				mockApi.InitMock()
+			},
+		},
+	}
+
+	for i := range testCases {
+		tc := testCases[i]
+
+		t.Run(tc.name, func(t *testing.T) {
+			// Arrange
+			tc.setup()
+			defer tc.tearDown()
+
+			// Act
+			err := app.Run(tc.commands)
+
+			// Assert
+			tc.assertion(t, err, mockApi)
+		})
+	}
+}


### PR DESCRIPTION
## やったこと

- 特定のリポジトリに対して統計情報を取得する
- トークンがある場合はヘッダーに設定する

## やってないこと

- 

## この MR 後の課題

- リポジトリ一覧の API と組み合わせて、全リポジトリのライン分を取得すること
  - #7 で対応予定

## そのほか

- Closed #5 
