### PR TITLE
Fix: go.GetEnv is not working problem

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,19 @@ Built binaries are available from GitHub Releases.
 
 https://github.com/kokoichi206/go-git-stats/releases
 
+### How to set environment varialbe
+
+**Linux**
+
+```sh
+# Write these two commands to .bashrc, .zshrc or etc. if you want.
+$ GGS_TOKEN=ghq_xxx
+$ export GGS_TOKEN
+
+# easier way
+$ GGS_TOKEN=ghq_pienpoyon ggs <sub-command>
+```
+
 ## LICENSE
 
 under [MIT License](./LICENSE).

--- a/util/config_test.go
+++ b/util/config_test.go
@@ -1,0 +1,61 @@
+package util
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestLoadConfig(t *testing.T) {
+
+	testCases := []struct {
+		name      string
+		setup     func()
+		assertion func(t *testing.T, config Config)
+		tearDown  func()
+	}{
+		{
+			name: "OK",
+			setup: func() {
+				os.Setenv("GGS_TOKEN", "ghq_foobarTOKEN")
+			},
+			assertion: func(t *testing.T, config Config) {
+				t.Log(config)
+				// GitHub REST API
+				require.Equal(t, "https://api.github.com", config.ApiBaseURL)
+				require.Equal(t, "ghq_foobarTOKEN", config.Token)
+			},
+			tearDown: func() {
+				os.Unsetenv("GGS_TOKEN")
+			},
+		},
+		{
+			name:  "OK without token",
+			setup: func() {},
+			assertion: func(t *testing.T, config Config) {
+				t.Log(config)
+				// GitHub REST API
+				require.Equal(t, "https://api.github.com", config.ApiBaseURL)
+				require.Equal(t, "", config.Token)
+			},
+			tearDown: func() {},
+		},
+	}
+
+	for i := range testCases {
+		tc := testCases[i]
+
+		t.Run(tc.name, func(t *testing.T) {
+			// Arrange
+			tc.setup()
+			defer tc.tearDown()
+
+			// Act
+			config := LoadConfig()
+
+			// Assert
+			tc.assertion(t, config)
+		})
+	}
+}


### PR DESCRIPTION
## やったこと

- LoadConfig に対するテストを追加
- README を整理

## やってないこと

- 

## この MR 後の課題

- 

## そのほか

- コード自体に問題はなく、自分の環境変数に対する理解不足が問題でした。
  - その辺を迷う人がいないよう、README に記載しました。
- できればテストのセットアップでは SetEnv は使いたくなかった（実装の GetEnv の逆実装のため）のですが、通常の設定方法（HOGE=hoge;export HOGE）でうまく動いてなさそうだったので仕方なく。。。
  - これについては記載あった → issue
- Closed #13 
